### PR TITLE
small changes

### DIFF
--- a/secrets_example.json
+++ b/secrets_example.json
@@ -26,6 +26,14 @@
       "namespaces": [
         "registry-backend"
       ]
+    },
+    "multichain-settings": {
+      "data": {
+        "host": "1.2.3.4"
+      },
+      "namespaces": [
+        "multichain-node"
+      ]
     }
   }
 }

--- a/storageClass.yml
+++ b/storageClass.yml
@@ -1,42 +1,9 @@
-allowVolumeExpansion: true
-apiVersion: storage.k8s.io/v1
 kind: StorageClass
+apiVersion: storage.k8s.io/v1
 metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"allowVolumeExpansion":true,"apiVersion":"storage.k8s.io/v1beta1","kind":"StorageClass","metadata":{"annotations":{},"labels":{"kubernetes.io/cluster-service":"true"},"name":"managed-premium"},"parameters":{"cachingmode":"ReadOnly","kind":"Managed","storageaccounttype":"Premium_LRS"},"provisioner":"kubernetes.io/azure-disk"}
-  creationTimestamp: null
-  labels:
-    kubernetes.io/cluster-service: "true"
-  managedFields:
-  - apiVersion: storage.k8s.io/v1beta1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:allowVolumeExpansion: {}
-      f:metadata:
-        f:annotations:
-          .: {}
-          f:kubectl.kubernetes.io/last-applied-configuration: {}
-        f:labels:
-          .: {}
-          f:kubernetes.io/cluster-service: {}
-      f:parameters:
-        .: {}
-        f:cachingmode: {}
-        f:kind: {}
-        f:storageaccounttype: {}
-      f:provisioner: {}
-      f:reclaimPolicy: {}
-      f:volumeBindingMode: {}
-    manager: kubectl
-    operation: Update
-    time: "2020-06-12T13:05:18Z"
   name: managed-premium-retain
-  selfLink: /apis/storage.k8s.io/v1/storageclasses/managed-premium
-parameters:
-  cachingmode: ReadOnly
-  kind: Managed
-  storageaccounttype: Premium_LRS
 provisioner: kubernetes.io/azure-disk
 reclaimPolicy: Retain
-volumeBindingMode: Immediate
+parameters:
+  storageaccounttype: Premium_LRS
+  kind: Managed


### PR DESCRIPTION
1. Cleanup storage class deployment file. This deployment file contains definitions for Azure Disks, which will be used by all the persistent volume claims of the pods.

1. Extended secrets_examples with a multichain node host address. Previously, it was hardcoded in the multichain deployment files. Now, participating parties can get the address from us and deploy it on the cluster via secrets.

Links to https://github.com/kadaster-labs/sensrnet-ops/issues/24